### PR TITLE
Fix ui when building in dot folder f.ex. .cache

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = gotify-server
 	pkgdesc = A simple server for sending and receiving messages in real-time per WebSocket.
 	pkgver = 2.0.15
-	pkgrel = 2
+	pkgrel = 3
 	url = https://gotify.net/
 	install = gotify-server.install
 	arch = x86_64

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -2,7 +2,7 @@
 # Contributor: ml <ml@visu.li>
 pkgname=gotify-server
 pkgver=2.0.15
-pkgrel=2
+pkgrel=3
 pkgdesc='A simple server for sending and receiving messages in real-time per WebSocket.'
 arch=('x86_64' 'i686' 'aarch64' 'armv7h')
 url='https://gotify.net/'
@@ -35,7 +35,7 @@ build() {
     yarn --frozen-lockfile
     NODE_ENV=production yarn --frozen-lockfile build
   )
-  go run hack/packr/packr.go
+  go run hack/packr/packr.go -- .
   export CGO_CFLAGS="$CFLAGS"
   export CGO_LDFLAGS="$LDFLAGS"
   export CGO_CPPFLAGS="$CPPFLAGS"


### PR DESCRIPTION
packr2 ignores all files that are inside a dot folder.
When explicitly declaring the directory it somehow works.

https://aur.archlinux.org/packages/gotify-server#comment-743066